### PR TITLE
Ensure scroller is cleared when end is reached

### DIFF
--- a/drag-scroll-behavior.html
+++ b/drag-scroll-behavior.html
@@ -112,6 +112,9 @@
           if(!this.atTop(this.scrollElement)) {
             this.scroll(-1);
           } else {
+            if(this.scroller) {
+              this.scrollStop()
+            }
             this.targetDisplayTop = 'none';
           }
         }
@@ -123,6 +126,9 @@
           if(!this.atBottom(this.scrollElement)) {
             this.scroll(1);
           } else {
+            if(this.scroller) {
+              this.scrollStop()
+            }
             this.targetDisplayBottom = 'none';
           }
         }


### PR DESCRIPTION
ff does not fire drag leave when target is hidden. Hence does not clear the scroller object when scroll reaches the end